### PR TITLE
ラベル設定、席分け設定以外の新規作成画面をAPI通信できる形にする

### DIFF
--- a/lib/model/entity/event.dart
+++ b/lib/model/entity/event.dart
@@ -18,9 +18,10 @@ class Event with _$Event {
     required String? location_name,
     required String? location_address,
     required double? location_latitude,
-    required double? location_longtiude,
+    required double? location_longitude,
     required int? group_num,
-    required int? total_cost,
+    required int? cost_type,
+    required int? cost,
     required String? questionare_url,
   }) = _Event;
 
@@ -37,6 +38,17 @@ class Event with _$Event {
     String str2 = DateFormat('HH:mm')
         .format(end_at ?? DateTime.now());
     return str1 + str2;
+  }
+
+  String getLocationText() {
+    String ret = '';
+    if(location_name != null) {
+      ret += '$location_name, ';
+    }
+    if(location_address != null) {
+      ret += location_address!;
+    }
+    return ret;
   }
 
   factory Event.fromJson(Map<String, Object?> json)

--- a/lib/model/entity/event_detail_state.dart
+++ b/lib/model/entity/event_detail_state.dart
@@ -14,5 +14,6 @@ class EventDetailState with _$EventDetailState {
     required Event event,
     required SplayTreeSet<ScheduleCandidate> scheduleCandidates,
     required List<Participant> participants,
+    required bool loading
   }) = _EventDetailState;
 }

--- a/lib/model/entity/event_update_state.dart
+++ b/lib/model/entity/event_update_state.dart
@@ -1,0 +1,19 @@
+import 'dart:collection';
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:schetify/model/entity/event.dart';
+import 'package:schetify/model/entity/participant.dart';
+import 'package:schetify/model/entity/schedule_candidate.dart';
+// {ファイル名}.freezed.dart　と書く
+part 'generated/event_update_state.freezed.dart';
+
+//Freezed特有の書き方なので、スニペットを用意するのが良い
+@freezed
+class EventUpdateState with _$EventUpdateState {
+  const factory EventUpdateState({
+    required Event event,
+    required SplayTreeSet<ScheduleCandidate> scheduleCandidates,
+    required List<Participant> participants,
+    required bool loading,
+  }) = _EventUpdateState;
+}

--- a/lib/model/entity/generated/event.freezed.dart
+++ b/lib/model/entity/generated/event.freezed.dart
@@ -29,9 +29,10 @@ mixin _$Event {
   String? get location_name => throw _privateConstructorUsedError;
   String? get location_address => throw _privateConstructorUsedError;
   double? get location_latitude => throw _privateConstructorUsedError;
-  double? get location_longtiude => throw _privateConstructorUsedError;
+  double? get location_longitude => throw _privateConstructorUsedError;
   int? get group_num => throw _privateConstructorUsedError;
-  int? get total_cost => throw _privateConstructorUsedError;
+  int? get cost_type => throw _privateConstructorUsedError;
+  int? get cost => throw _privateConstructorUsedError;
   String? get questionare_url => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -53,9 +54,10 @@ abstract class $EventCopyWith<$Res> {
       String? location_name,
       String? location_address,
       double? location_latitude,
-      double? location_longtiude,
+      double? location_longitude,
       int? group_num,
-      int? total_cost,
+      int? cost_type,
+      int? cost,
       String? questionare_url});
 }
 
@@ -78,9 +80,10 @@ class _$EventCopyWithImpl<$Res> implements $EventCopyWith<$Res> {
     Object? location_name = freezed,
     Object? location_address = freezed,
     Object? location_latitude = freezed,
-    Object? location_longtiude = freezed,
+    Object? location_longitude = freezed,
     Object? group_num = freezed,
-    Object? total_cost = freezed,
+    Object? cost_type = freezed,
+    Object? cost = freezed,
     Object? questionare_url = freezed,
   }) {
     return _then(_value.copyWith(
@@ -120,17 +123,21 @@ class _$EventCopyWithImpl<$Res> implements $EventCopyWith<$Res> {
           ? _value.location_latitude
           : location_latitude // ignore: cast_nullable_to_non_nullable
               as double?,
-      location_longtiude: location_longtiude == freezed
-          ? _value.location_longtiude
-          : location_longtiude // ignore: cast_nullable_to_non_nullable
+      location_longitude: location_longitude == freezed
+          ? _value.location_longitude
+          : location_longitude // ignore: cast_nullable_to_non_nullable
               as double?,
       group_num: group_num == freezed
           ? _value.group_num
           : group_num // ignore: cast_nullable_to_non_nullable
               as int?,
-      total_cost: total_cost == freezed
-          ? _value.total_cost
-          : total_cost // ignore: cast_nullable_to_non_nullable
+      cost_type: cost_type == freezed
+          ? _value.cost_type
+          : cost_type // ignore: cast_nullable_to_non_nullable
+              as int?,
+      cost: cost == freezed
+          ? _value.cost
+          : cost // ignore: cast_nullable_to_non_nullable
               as int?,
       questionare_url: questionare_url == freezed
           ? _value.questionare_url
@@ -155,9 +162,10 @@ abstract class _$$_EventCopyWith<$Res> implements $EventCopyWith<$Res> {
       String? location_name,
       String? location_address,
       double? location_latitude,
-      double? location_longtiude,
+      double? location_longitude,
       int? group_num,
-      int? total_cost,
+      int? cost_type,
+      int? cost,
       String? questionare_url});
 }
 
@@ -181,9 +189,10 @@ class __$$_EventCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
     Object? location_name = freezed,
     Object? location_address = freezed,
     Object? location_latitude = freezed,
-    Object? location_longtiude = freezed,
+    Object? location_longitude = freezed,
     Object? group_num = freezed,
-    Object? total_cost = freezed,
+    Object? cost_type = freezed,
+    Object? cost = freezed,
     Object? questionare_url = freezed,
   }) {
     return _then(_$_Event(
@@ -223,17 +232,21 @@ class __$$_EventCopyWithImpl<$Res> extends _$EventCopyWithImpl<$Res>
           ? _value.location_latitude
           : location_latitude // ignore: cast_nullable_to_non_nullable
               as double?,
-      location_longtiude: location_longtiude == freezed
-          ? _value.location_longtiude
-          : location_longtiude // ignore: cast_nullable_to_non_nullable
+      location_longitude: location_longitude == freezed
+          ? _value.location_longitude
+          : location_longitude // ignore: cast_nullable_to_non_nullable
               as double?,
       group_num: group_num == freezed
           ? _value.group_num
           : group_num // ignore: cast_nullable_to_non_nullable
               as int?,
-      total_cost: total_cost == freezed
-          ? _value.total_cost
-          : total_cost // ignore: cast_nullable_to_non_nullable
+      cost_type: cost_type == freezed
+          ? _value.cost_type
+          : cost_type // ignore: cast_nullable_to_non_nullable
+              as int?,
+      cost: cost == freezed
+          ? _value.cost
+          : cost // ignore: cast_nullable_to_non_nullable
               as int?,
       questionare_url: questionare_url == freezed
           ? _value.questionare_url
@@ -256,9 +269,10 @@ class _$_Event extends _Event {
       required this.location_name,
       required this.location_address,
       required this.location_latitude,
-      required this.location_longtiude,
+      required this.location_longitude,
       required this.group_num,
-      required this.total_cost,
+      required this.cost_type,
+      required this.cost,
       required this.questionare_url})
       : super._();
 
@@ -284,17 +298,19 @@ class _$_Event extends _Event {
   @override
   final double? location_latitude;
   @override
-  final double? location_longtiude;
+  final double? location_longitude;
   @override
   final int? group_num;
   @override
-  final int? total_cost;
+  final int? cost_type;
+  @override
+  final int? cost;
   @override
   final String? questionare_url;
 
   @override
   String toString() {
-    return 'Event(id: $id, name: $name, description: $description, start_at: $start_at, end_at: $end_at, img_url: $img_url, location_name: $location_name, location_address: $location_address, location_latitude: $location_latitude, location_longtiude: $location_longtiude, group_num: $group_num, total_cost: $total_cost, questionare_url: $questionare_url)';
+    return 'Event(id: $id, name: $name, description: $description, start_at: $start_at, end_at: $end_at, img_url: $img_url, location_name: $location_name, location_address: $location_address, location_latitude: $location_latitude, location_longitude: $location_longitude, group_num: $group_num, cost_type: $cost_type, cost: $cost, questionare_url: $questionare_url)';
   }
 
   @override
@@ -316,10 +332,10 @@ class _$_Event extends _Event {
             const DeepCollectionEquality()
                 .equals(other.location_latitude, location_latitude) &&
             const DeepCollectionEquality()
-                .equals(other.location_longtiude, location_longtiude) &&
+                .equals(other.location_longitude, location_longitude) &&
             const DeepCollectionEquality().equals(other.group_num, group_num) &&
-            const DeepCollectionEquality()
-                .equals(other.total_cost, total_cost) &&
+            const DeepCollectionEquality().equals(other.cost_type, cost_type) &&
+            const DeepCollectionEquality().equals(other.cost, cost) &&
             const DeepCollectionEquality()
                 .equals(other.questionare_url, questionare_url));
   }
@@ -337,9 +353,10 @@ class _$_Event extends _Event {
       const DeepCollectionEquality().hash(location_name),
       const DeepCollectionEquality().hash(location_address),
       const DeepCollectionEquality().hash(location_latitude),
-      const DeepCollectionEquality().hash(location_longtiude),
+      const DeepCollectionEquality().hash(location_longitude),
       const DeepCollectionEquality().hash(group_num),
-      const DeepCollectionEquality().hash(total_cost),
+      const DeepCollectionEquality().hash(cost_type),
+      const DeepCollectionEquality().hash(cost),
       const DeepCollectionEquality().hash(questionare_url));
 
   @JsonKey(ignore: true)
@@ -366,9 +383,10 @@ abstract class _Event extends Event {
       required final String? location_name,
       required final String? location_address,
       required final double? location_latitude,
-      required final double? location_longtiude,
+      required final double? location_longitude,
       required final int? group_num,
-      required final int? total_cost,
+      required final int? cost_type,
+      required final int? cost,
       required final String? questionare_url}) = _$_Event;
   const _Event._() : super._();
 
@@ -393,11 +411,13 @@ abstract class _Event extends Event {
   @override
   double? get location_latitude;
   @override
-  double? get location_longtiude;
+  double? get location_longitude;
   @override
   int? get group_num;
   @override
-  int? get total_cost;
+  int? get cost_type;
+  @override
+  int? get cost;
   @override
   String? get questionare_url;
   @override

--- a/lib/model/entity/generated/event.g.dart
+++ b/lib/model/entity/generated/event.g.dart
@@ -20,9 +20,10 @@ _$_Event _$$_EventFromJson(Map<String, dynamic> json) => _$_Event(
       location_name: json['location_name'] as String?,
       location_address: json['location_address'] as String?,
       location_latitude: (json['location_latitude'] as num?)?.toDouble(),
-      location_longtiude: (json['location_longtiude'] as num?)?.toDouble(),
+      location_longitude: (json['location_longitude'] as num?)?.toDouble(),
       group_num: json['group_num'] as int?,
-      total_cost: json['total_cost'] as int?,
+      cost_type: json['cost_type'] as int?,
+      cost: json['cost'] as int?,
       questionare_url: json['questionare_url'] as String?,
     );
 
@@ -36,8 +37,9 @@ Map<String, dynamic> _$$_EventToJson(_$_Event instance) => <String, dynamic>{
       'location_name': instance.location_name,
       'location_address': instance.location_address,
       'location_latitude': instance.location_latitude,
-      'location_longtiude': instance.location_longtiude,
+      'location_longitude': instance.location_longitude,
       'group_num': instance.group_num,
-      'total_cost': instance.total_cost,
+      'cost_type': instance.cost_type,
+      'cost': instance.cost,
       'questionare_url': instance.questionare_url,
     };

--- a/lib/model/entity/generated/event_detail_state.freezed.dart
+++ b/lib/model/entity/generated/event_detail_state.freezed.dart
@@ -20,6 +20,7 @@ mixin _$EventDetailState {
   SplayTreeSet<ScheduleCandidate> get scheduleCandidates =>
       throw _privateConstructorUsedError;
   List<Participant> get participants => throw _privateConstructorUsedError;
+  bool get loading => throw _privateConstructorUsedError;
 
   @JsonKey(ignore: true)
   $EventDetailStateCopyWith<EventDetailState> get copyWith =>
@@ -34,7 +35,8 @@ abstract class $EventDetailStateCopyWith<$Res> {
   $Res call(
       {Event event,
       SplayTreeSet<ScheduleCandidate> scheduleCandidates,
-      List<Participant> participants});
+      List<Participant> participants,
+      bool loading});
 
   $EventCopyWith<$Res> get event;
 }
@@ -53,6 +55,7 @@ class _$EventDetailStateCopyWithImpl<$Res>
     Object? event = freezed,
     Object? scheduleCandidates = freezed,
     Object? participants = freezed,
+    Object? loading = freezed,
   }) {
     return _then(_value.copyWith(
       event: event == freezed
@@ -67,6 +70,10 @@ class _$EventDetailStateCopyWithImpl<$Res>
           ? _value.participants
           : participants // ignore: cast_nullable_to_non_nullable
               as List<Participant>,
+      loading: loading == freezed
+          ? _value.loading
+          : loading // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 
@@ -88,7 +95,8 @@ abstract class _$$_EventDetailStateCopyWith<$Res>
   $Res call(
       {Event event,
       SplayTreeSet<ScheduleCandidate> scheduleCandidates,
-      List<Participant> participants});
+      List<Participant> participants,
+      bool loading});
 
   @override
   $EventCopyWith<$Res> get event;
@@ -110,6 +118,7 @@ class __$$_EventDetailStateCopyWithImpl<$Res>
     Object? event = freezed,
     Object? scheduleCandidates = freezed,
     Object? participants = freezed,
+    Object? loading = freezed,
   }) {
     return _then(_$_EventDetailState(
       event: event == freezed
@@ -124,6 +133,10 @@ class __$$_EventDetailStateCopyWithImpl<$Res>
           ? _value._participants
           : participants // ignore: cast_nullable_to_non_nullable
               as List<Participant>,
+      loading: loading == freezed
+          ? _value.loading
+          : loading // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -134,7 +147,8 @@ class _$_EventDetailState implements _EventDetailState {
   const _$_EventDetailState(
       {required this.event,
       required this.scheduleCandidates,
-      required final List<Participant> participants})
+      required final List<Participant> participants,
+      required this.loading})
       : _participants = participants;
 
   @override
@@ -149,8 +163,11 @@ class _$_EventDetailState implements _EventDetailState {
   }
 
   @override
+  final bool loading;
+
+  @override
   String toString() {
-    return 'EventDetailState(event: $event, scheduleCandidates: $scheduleCandidates, participants: $participants)';
+    return 'EventDetailState(event: $event, scheduleCandidates: $scheduleCandidates, participants: $participants, loading: $loading)';
   }
 
   @override
@@ -162,7 +179,8 @@ class _$_EventDetailState implements _EventDetailState {
             const DeepCollectionEquality()
                 .equals(other.scheduleCandidates, scheduleCandidates) &&
             const DeepCollectionEquality()
-                .equals(other._participants, _participants));
+                .equals(other._participants, _participants) &&
+            const DeepCollectionEquality().equals(other.loading, loading));
   }
 
   @override
@@ -170,7 +188,8 @@ class _$_EventDetailState implements _EventDetailState {
       runtimeType,
       const DeepCollectionEquality().hash(event),
       const DeepCollectionEquality().hash(scheduleCandidates),
-      const DeepCollectionEquality().hash(_participants));
+      const DeepCollectionEquality().hash(_participants),
+      const DeepCollectionEquality().hash(loading));
 
   @JsonKey(ignore: true)
   @override
@@ -182,7 +201,8 @@ abstract class _EventDetailState implements EventDetailState {
   const factory _EventDetailState(
       {required final Event event,
       required final SplayTreeSet<ScheduleCandidate> scheduleCandidates,
-      required final List<Participant> participants}) = _$_EventDetailState;
+      required final List<Participant> participants,
+      required final bool loading}) = _$_EventDetailState;
 
   @override
   Event get event;
@@ -190,6 +210,8 @@ abstract class _EventDetailState implements EventDetailState {
   SplayTreeSet<ScheduleCandidate> get scheduleCandidates;
   @override
   List<Participant> get participants;
+  @override
+  bool get loading;
   @override
   @JsonKey(ignore: true)
   _$$_EventDetailStateCopyWith<_$_EventDetailState> get copyWith =>

--- a/lib/model/entity/generated/event_update_state.freezed.dart
+++ b/lib/model/entity/generated/event_update_state.freezed.dart
@@ -1,0 +1,219 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of '../event_update_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$EventUpdateState {
+  Event get event => throw _privateConstructorUsedError;
+  SplayTreeSet<ScheduleCandidate> get scheduleCandidates =>
+      throw _privateConstructorUsedError;
+  List<Participant> get participants => throw _privateConstructorUsedError;
+  bool get loading => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $EventUpdateStateCopyWith<EventUpdateState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $EventUpdateStateCopyWith<$Res> {
+  factory $EventUpdateStateCopyWith(
+          EventUpdateState value, $Res Function(EventUpdateState) then) =
+      _$EventUpdateStateCopyWithImpl<$Res>;
+  $Res call(
+      {Event event,
+      SplayTreeSet<ScheduleCandidate> scheduleCandidates,
+      List<Participant> participants,
+      bool loading});
+
+  $EventCopyWith<$Res> get event;
+}
+
+/// @nodoc
+class _$EventUpdateStateCopyWithImpl<$Res>
+    implements $EventUpdateStateCopyWith<$Res> {
+  _$EventUpdateStateCopyWithImpl(this._value, this._then);
+
+  final EventUpdateState _value;
+  // ignore: unused_field
+  final $Res Function(EventUpdateState) _then;
+
+  @override
+  $Res call({
+    Object? event = freezed,
+    Object? scheduleCandidates = freezed,
+    Object? participants = freezed,
+    Object? loading = freezed,
+  }) {
+    return _then(_value.copyWith(
+      event: event == freezed
+          ? _value.event
+          : event // ignore: cast_nullable_to_non_nullable
+              as Event,
+      scheduleCandidates: scheduleCandidates == freezed
+          ? _value.scheduleCandidates
+          : scheduleCandidates // ignore: cast_nullable_to_non_nullable
+              as SplayTreeSet<ScheduleCandidate>,
+      participants: participants == freezed
+          ? _value.participants
+          : participants // ignore: cast_nullable_to_non_nullable
+              as List<Participant>,
+      loading: loading == freezed
+          ? _value.loading
+          : loading // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+
+  @override
+  $EventCopyWith<$Res> get event {
+    return $EventCopyWith<$Res>(_value.event, (value) {
+      return _then(_value.copyWith(event: value));
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$_EventUpdateStateCopyWith<$Res>
+    implements $EventUpdateStateCopyWith<$Res> {
+  factory _$$_EventUpdateStateCopyWith(
+          _$_EventUpdateState value, $Res Function(_$_EventUpdateState) then) =
+      __$$_EventUpdateStateCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {Event event,
+      SplayTreeSet<ScheduleCandidate> scheduleCandidates,
+      List<Participant> participants,
+      bool loading});
+
+  @override
+  $EventCopyWith<$Res> get event;
+}
+
+/// @nodoc
+class __$$_EventUpdateStateCopyWithImpl<$Res>
+    extends _$EventUpdateStateCopyWithImpl<$Res>
+    implements _$$_EventUpdateStateCopyWith<$Res> {
+  __$$_EventUpdateStateCopyWithImpl(
+      _$_EventUpdateState _value, $Res Function(_$_EventUpdateState) _then)
+      : super(_value, (v) => _then(v as _$_EventUpdateState));
+
+  @override
+  _$_EventUpdateState get _value => super._value as _$_EventUpdateState;
+
+  @override
+  $Res call({
+    Object? event = freezed,
+    Object? scheduleCandidates = freezed,
+    Object? participants = freezed,
+    Object? loading = freezed,
+  }) {
+    return _then(_$_EventUpdateState(
+      event: event == freezed
+          ? _value.event
+          : event // ignore: cast_nullable_to_non_nullable
+              as Event,
+      scheduleCandidates: scheduleCandidates == freezed
+          ? _value.scheduleCandidates
+          : scheduleCandidates // ignore: cast_nullable_to_non_nullable
+              as SplayTreeSet<ScheduleCandidate>,
+      participants: participants == freezed
+          ? _value._participants
+          : participants // ignore: cast_nullable_to_non_nullable
+              as List<Participant>,
+      loading: loading == freezed
+          ? _value.loading
+          : loading // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_EventUpdateState implements _EventUpdateState {
+  const _$_EventUpdateState(
+      {required this.event,
+      required this.scheduleCandidates,
+      required final List<Participant> participants,
+      required this.loading})
+      : _participants = participants;
+
+  @override
+  final Event event;
+  @override
+  final SplayTreeSet<ScheduleCandidate> scheduleCandidates;
+  final List<Participant> _participants;
+  @override
+  List<Participant> get participants {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_participants);
+  }
+
+  @override
+  final bool loading;
+
+  @override
+  String toString() {
+    return 'EventUpdateState(event: $event, scheduleCandidates: $scheduleCandidates, participants: $participants, loading: $loading)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_EventUpdateState &&
+            const DeepCollectionEquality().equals(other.event, event) &&
+            const DeepCollectionEquality()
+                .equals(other.scheduleCandidates, scheduleCandidates) &&
+            const DeepCollectionEquality()
+                .equals(other._participants, _participants) &&
+            const DeepCollectionEquality().equals(other.loading, loading));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(event),
+      const DeepCollectionEquality().hash(scheduleCandidates),
+      const DeepCollectionEquality().hash(_participants),
+      const DeepCollectionEquality().hash(loading));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_EventUpdateStateCopyWith<_$_EventUpdateState> get copyWith =>
+      __$$_EventUpdateStateCopyWithImpl<_$_EventUpdateState>(this, _$identity);
+}
+
+abstract class _EventUpdateState implements EventUpdateState {
+  const factory _EventUpdateState(
+      {required final Event event,
+      required final SplayTreeSet<ScheduleCandidate> scheduleCandidates,
+      required final List<Participant> participants,
+      required final bool loading}) = _$_EventUpdateState;
+
+  @override
+  Event get event;
+  @override
+  SplayTreeSet<ScheduleCandidate> get scheduleCandidates;
+  @override
+  List<Participant> get participants;
+  @override
+  bool get loading;
+  @override
+  @JsonKey(ignore: true)
+  _$$_EventUpdateStateCopyWith<_$_EventUpdateState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/entity/generated/participant.freezed.dart
+++ b/lib/model/entity/generated/participant.freezed.dart
@@ -23,7 +23,7 @@ mixin _$Participant {
   String get user_id => throw _privateConstructorUsedError;
   String get username => throw _privateConstructorUsedError;
   int get label => throw _privateConstructorUsedError;
-  int get group_id => throw _privateConstructorUsedError;
+  int? get group_id => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -36,7 +36,7 @@ abstract class $ParticipantCopyWith<$Res> {
   factory $ParticipantCopyWith(
           Participant value, $Res Function(Participant) then) =
       _$ParticipantCopyWithImpl<$Res>;
-  $Res call({String user_id, String username, int label, int group_id});
+  $Res call({String user_id, String username, int label, int? group_id});
 }
 
 /// @nodoc
@@ -70,7 +70,7 @@ class _$ParticipantCopyWithImpl<$Res> implements $ParticipantCopyWith<$Res> {
       group_id: group_id == freezed
           ? _value.group_id
           : group_id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
     ));
   }
 }
@@ -82,7 +82,7 @@ abstract class _$$_ParticipantCopyWith<$Res>
           _$_Participant value, $Res Function(_$_Participant) then) =
       __$$_ParticipantCopyWithImpl<$Res>;
   @override
-  $Res call({String user_id, String username, int label, int group_id});
+  $Res call({String user_id, String username, int label, int? group_id});
 }
 
 /// @nodoc
@@ -118,7 +118,7 @@ class __$$_ParticipantCopyWithImpl<$Res> extends _$ParticipantCopyWithImpl<$Res>
       group_id: group_id == freezed
           ? _value.group_id
           : group_id // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
     ));
   }
 }
@@ -142,7 +142,7 @@ class _$_Participant implements _Participant {
   @override
   final int label;
   @override
-  final int group_id;
+  final int? group_id;
 
   @override
   String toString() {
@@ -187,7 +187,7 @@ abstract class _Participant implements Participant {
       {required final String user_id,
       required final String username,
       required final int label,
-      required final int group_id}) = _$_Participant;
+      required final int? group_id}) = _$_Participant;
 
   factory _Participant.fromJson(Map<String, dynamic> json) =
       _$_Participant.fromJson;
@@ -199,7 +199,7 @@ abstract class _Participant implements Participant {
   @override
   int get label;
   @override
-  int get group_id;
+  int? get group_id;
   @override
   @JsonKey(ignore: true)
   _$$_ParticipantCopyWith<_$_Participant> get copyWith =>

--- a/lib/model/entity/generated/participant.g.dart
+++ b/lib/model/entity/generated/participant.g.dart
@@ -11,7 +11,7 @@ _$_Participant _$$_ParticipantFromJson(Map<String, dynamic> json) =>
       user_id: json['user_id'] as String,
       username: json['username'] as String,
       label: json['label'] as int,
-      group_id: json['group_id'] as int,
+      group_id: json['group_id'] as int?,
     );
 
 Map<String, dynamic> _$$_ParticipantToJson(_$_Participant instance) =>

--- a/lib/model/entity/generated/schedule_candidate.freezed.dart
+++ b/lib/model/entity/generated/schedule_candidate.freezed.dart
@@ -21,6 +21,7 @@ ScheduleCandidate _$ScheduleCandidateFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$ScheduleCandidate {
   int? get id => throw _privateConstructorUsedError;
+  int? get event_id => throw _privateConstructorUsedError;
   DateTime get start_at => throw _privateConstructorUsedError;
   DateTime get end_at => throw _privateConstructorUsedError;
   @VoterListConverter()
@@ -39,6 +40,7 @@ abstract class $ScheduleCandidateCopyWith<$Res> {
       _$ScheduleCandidateCopyWithImpl<$Res>;
   $Res call(
       {int? id,
+      int? event_id,
       DateTime start_at,
       DateTime end_at,
       @VoterListConverter() List<Voter> voters});
@@ -56,6 +58,7 @@ class _$ScheduleCandidateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? id = freezed,
+    Object? event_id = freezed,
     Object? start_at = freezed,
     Object? end_at = freezed,
     Object? voters = freezed,
@@ -64,6 +67,10 @@ class _$ScheduleCandidateCopyWithImpl<$Res>
       id: id == freezed
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
+              as int?,
+      event_id: event_id == freezed
+          ? _value.event_id
+          : event_id // ignore: cast_nullable_to_non_nullable
               as int?,
       start_at: start_at == freezed
           ? _value.start_at
@@ -90,6 +97,7 @@ abstract class _$$_ScheduleCandidateCopyWith<$Res>
   @override
   $Res call(
       {int? id,
+      int? event_id,
       DateTime start_at,
       DateTime end_at,
       @VoterListConverter() List<Voter> voters});
@@ -109,6 +117,7 @@ class __$$_ScheduleCandidateCopyWithImpl<$Res>
   @override
   $Res call({
     Object? id = freezed,
+    Object? event_id = freezed,
     Object? start_at = freezed,
     Object? end_at = freezed,
     Object? voters = freezed,
@@ -117,6 +126,10 @@ class __$$_ScheduleCandidateCopyWithImpl<$Res>
       id: id == freezed
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
+              as int?,
+      event_id: event_id == freezed
+          ? _value.event_id
+          : event_id // ignore: cast_nullable_to_non_nullable
               as int?,
       start_at: start_at == freezed
           ? _value.start_at
@@ -139,6 +152,7 @@ class __$$_ScheduleCandidateCopyWithImpl<$Res>
 class _$_ScheduleCandidate extends _ScheduleCandidate {
   const _$_ScheduleCandidate(
       {required this.id,
+      required this.event_id,
       required this.start_at,
       required this.end_at,
       @VoterListConverter() required final List<Voter> voters})
@@ -150,6 +164,8 @@ class _$_ScheduleCandidate extends _ScheduleCandidate {
 
   @override
   final int? id;
+  @override
+  final int? event_id;
   @override
   final DateTime start_at;
   @override
@@ -164,7 +180,7 @@ class _$_ScheduleCandidate extends _ScheduleCandidate {
 
   @override
   String toString() {
-    return 'ScheduleCandidate(id: $id, start_at: $start_at, end_at: $end_at, voters: $voters)';
+    return 'ScheduleCandidate(id: $id, event_id: $event_id, start_at: $start_at, end_at: $end_at, voters: $voters)';
   }
 
   @JsonKey(ignore: true)
@@ -184,6 +200,7 @@ class _$_ScheduleCandidate extends _ScheduleCandidate {
 abstract class _ScheduleCandidate extends ScheduleCandidate {
   const factory _ScheduleCandidate(
           {required final int? id,
+          required final int? event_id,
           required final DateTime start_at,
           required final DateTime end_at,
           @VoterListConverter() required final List<Voter> voters}) =
@@ -195,6 +212,8 @@ abstract class _ScheduleCandidate extends ScheduleCandidate {
 
   @override
   int? get id;
+  @override
+  int? get event_id;
   @override
   DateTime get start_at;
   @override

--- a/lib/model/entity/generated/schedule_candidate.g.dart
+++ b/lib/model/entity/generated/schedule_candidate.g.dart
@@ -9,6 +9,7 @@ part of '../schedule_candidate.dart';
 _$_ScheduleCandidate _$$_ScheduleCandidateFromJson(Map<String, dynamic> json) =>
     _$_ScheduleCandidate(
       id: json['id'] as int?,
+      event_id: json['event_id'] as int?,
       start_at: DateTime.parse(json['start_at'] as String),
       end_at: DateTime.parse(json['end_at'] as String),
       voters: const VoterListConverter()
@@ -19,6 +20,7 @@ Map<String, dynamic> _$$_ScheduleCandidateToJson(
         _$_ScheduleCandidate instance) =>
     <String, dynamic>{
       'id': instance.id,
+      'event_id': instance.event_id,
       'start_at': instance.start_at.toIso8601String(),
       'end_at': instance.end_at.toIso8601String(),
       'voters': const VoterListConverter().toJson(instance.voters),

--- a/lib/model/entity/participant.dart
+++ b/lib/model/entity/participant.dart
@@ -10,7 +10,7 @@ class Participant with _$Participant {
     required String user_id,
     required String username,
     required int label,
-    required int group_id,
+    required int? group_id,
   }) = _Participant;
 
   factory Participant.fromJson(Map<String, Object?> json)

--- a/lib/model/entity/schedule_candidate.dart
+++ b/lib/model/entity/schedule_candidate.dart
@@ -11,6 +11,7 @@ class ScheduleCandidate with _$ScheduleCandidate {
   const ScheduleCandidate._();
   const factory ScheduleCandidate({
     required int? id,
+    required int? event_id,
     required DateTime start_at,
     required DateTime end_at,
     @VoterListConverter() required List<Voter> voters,

--- a/lib/model/repository/test_repository.dart
+++ b/lib/model/repository/test_repository.dart
@@ -29,6 +29,13 @@ class TestRepository{
     }
   }
 
+  Future<int> updateEvent(Map<String, dynamic> json) async {
+    print(json);
+    await Future.delayed(const Duration(seconds: 1));
+    const status = 200;
+    return status;
+  }
+
   Future<List<Event>> getEvents() async {
     final data = [
       {
@@ -42,7 +49,8 @@ class TestRepository{
         'location_latitude': 35.679804878221226,
         'location_longitude': 139.7369627,
         'group_num': 4,
-        'total_cost': 3,
+        'cost': 30000,
+        'cost_flag': 0
       },
       {
         'id': 2,
@@ -68,7 +76,8 @@ class TestRepository{
       'location_latitude': 35.679804878221226,
       'location_longitude': 139.7369627,
       'group_num': 2,
-      'total_cost': 3,
+      'cost': 30000,
+      'cost_type': 0
     };
     return Event.fromJson(data);
   }
@@ -245,5 +254,10 @@ class TestRepository{
     final list = List<ScheduleCandidate>.from(data.map((element)=> ScheduleCandidate.fromJson(element)));
     for (var c in list) { set.add(c); }
     return set;
+  }
+
+  Future<int> updateScheduleCandidates(int? id, List<Map<String, dynamic>> data) async {
+    const status = 200;
+    return status;
   }
 }

--- a/lib/model/repository/test_repository.dart
+++ b/lib/model/repository/test_repository.dart
@@ -260,4 +260,15 @@ class TestRepository{
     const status = 200;
     return status;
   }
+
+  Future<Map<String, int>> createEvent(Map<String, String?> data) async {
+    await Future.delayed(const Duration(seconds: 1));
+    const id = 2;
+    const status = 200;
+    final set = {
+      'id': id,
+      'status': status
+    };
+    return set;
+  }
 }

--- a/lib/provider/event_detail_provider.dart
+++ b/lib/provider/event_detail_provider.dart
@@ -28,18 +28,29 @@ class EventDetailNotifier extends StateNotifier<EventDetailState> {
           questionare_url: null
       ),
       scheduleCandidates: SplayTreeSet<ScheduleCandidate>((a, b) => a.getText().compareTo(b.getText())),
-      participants: []
+      participants: [],
+      loading: true
   ));
 
   final TestRepository testService = TestRepository();
 
+  void changeLoading(bool loading) {
+    state = state.copyWith(loading: loading);
+  }
+
   Future<void> getEventInformation(int id) async {
     try{
+      changeLoading(true);
       await Future.delayed(const Duration(seconds: 1));
       final event = await testService.getEvent(id);
       final participants = await testService.getParticipants(id);
       final candidates = await testService.getScheduleCandidates(id);
-      state = state.copyWith(event: event, participants: participants, scheduleCandidates: candidates);
+      state = state.copyWith(
+          event: event,
+          participants: participants,
+          scheduleCandidates: candidates,
+          loading: false
+      );
     }catch(e){
       debugPrint(e.toString());
     }

--- a/lib/provider/event_detail_provider.dart
+++ b/lib/provider/event_detail_provider.dart
@@ -12,8 +12,8 @@ import 'package:schetify/model/repository/test_repository.dart';
 class EventDetailNotifier extends StateNotifier<EventDetailState> {
   EventDetailNotifier() : super(EventDetailState(
       event: const Event(
-          id: 1,
-          name: "test",
+          id: null,
+          name: null,
           description: null,
           start_at: null,
           end_at: null,
@@ -21,16 +21,15 @@ class EventDetailNotifier extends StateNotifier<EventDetailState> {
           location_name: null,
           location_address: null,
           location_latitude: null,
-          location_longtiude: null,
+          location_longitude: null,
           group_num: null,
-          total_cost: null,
+          cost: null,
+          cost_type: null,
           questionare_url: null
       ),
       scheduleCandidates: SplayTreeSet<ScheduleCandidate>((a, b) => a.getText().compareTo(b.getText())),
       participants: []
-  )){
-    init();
-  }
+  ));
 
   final TestRepository testService = TestRepository();
 
@@ -44,43 +43,6 @@ class EventDetailNotifier extends StateNotifier<EventDetailState> {
     }catch(e){
       debugPrint(e.toString());
     }
-  }
-
-  void init(){
-    List<ScheduleCandidate> list = [
-      ScheduleCandidate(
-          id: 1,
-          start_at: DateTime(2022, 9, 5, 12, 0),
-          end_at: DateTime(2022, 9, 5, 13, 0),
-          voters: []
-      ),
-      ScheduleCandidate(
-          id: 2,
-          start_at: DateTime(2022, 9, 6, 12, 0),
-          end_at: DateTime(2022, 9, 6, 13, 0),
-          voters: []
-      ),
-      ScheduleCandidate(
-          id: 3,
-          start_at: DateTime(2022, 9, 7, 12, 0),
-          end_at: DateTime(2022, 9, 7, 13, 0),
-          voters: []
-      ),
-      ScheduleCandidate(
-          id: 4,
-          start_at: DateTime(2022, 9, 8, 12, 0),
-          end_at: DateTime(2022, 9, 8, 13, 0),
-          voters: []
-      ),
-      ScheduleCandidate(
-          id: 5,
-          start_at: DateTime(2022, 9, 4, 12, 0),
-          end_at: DateTime(2022, 9, 4, 13, 0),
-          voters: []
-      ),
-    ];
-    for (var c in list) { state.scheduleCandidates.add(c); }
-    state = state.copyWith(scheduleCandidates: state.scheduleCandidates);
   }
 }
 

--- a/lib/provider/event_detail_provider.dart
+++ b/lib/provider/event_detail_provider.dart
@@ -55,6 +55,15 @@ class EventDetailNotifier extends StateNotifier<EventDetailState> {
       debugPrint(e.toString());
     }
   }
+
+  Future<int> updateSchedule(DateTime startAt, DateTime endAt) async{
+    final data = {
+      'start_at': startAt.toString(),
+      'end_at': endAt.toString(),
+    };
+    final status = await testService.updateEvent(data);
+    return status;
+  }
 }
 
 final eventDetailProvider = StateNotifierProvider<EventDetailNotifier

--- a/lib/provider/event_list_provider.dart
+++ b/lib/provider/event_list_provider.dart
@@ -31,7 +31,9 @@ class EventDataNotifier extends StateNotifier<EventList> {
   }
 
   Future<void> getEvents() async {
+    changeLoading(true);
     try{
+      await Future.delayed(const Duration(seconds: 1));
       final events = await testService.getEvents();
       state = EventList(loading: false, error: false, eventList: events);
     }catch(e){

--- a/lib/provider/event_update_provider.dart
+++ b/lib/provider/event_update_provider.dart
@@ -89,6 +89,19 @@ class EventUpdateNotifier extends StateNotifier<EventUpdateState> {
     state = state.copyWith(event: event);
   }
 
+  Future<int> updateName(String? name) async{
+    final data = {
+      'name': name
+    };
+    int status;
+    if(name != null && name != '') {
+      status = await testService.updateEvent(data);
+    }
+    else {
+      status = 400;
+    }
+    return status;
+  }
 
   Future<int> updateDescription(String? description) async{
     final data = {

--- a/lib/provider/event_update_provider.dart
+++ b/lib/provider/event_update_provider.dart
@@ -1,0 +1,154 @@
+
+
+import 'dart:collection';
+
+import 'package:flutter/cupertino.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schetify/model/entity/event.dart';
+import 'package:schetify/model/entity/schedule_candidate.dart';
+import 'package:schetify/model/repository/test_repository.dart';
+
+import '../model/entity/event_update_state.dart';
+
+class EventUpdateNotifier extends StateNotifier<EventUpdateState> {
+  EventUpdateNotifier() : super(EventUpdateState(
+      event: const Event(
+          id: null,
+          name: null,
+          description: null,
+          start_at: null,
+          end_at: null,
+          img_url: null,
+          location_name: null,
+          location_address: null,
+          location_latitude: null,
+          location_longitude: null,
+          group_num: null,
+          cost: null,
+          cost_type: null,
+          questionare_url: null
+      ),
+      scheduleCandidates: SplayTreeSet<ScheduleCandidate>((a, b) => a.getText().compareTo(b.getText())),
+      participants: [],
+    loading: true,
+  ));
+
+  final TestRepository testService = TestRepository();
+
+  Future<void> getEventInformation(int id) async {
+    try{
+      state = state.copyWith(loading: true);
+      await Future.delayed(const Duration(seconds: 1));
+      final event = await testService.getEvent(id);
+      final participants = await testService.getParticipants(id);
+      final candidates = await testService.getScheduleCandidates(id);
+      state = state.copyWith(
+          event: event,
+          participants: participants,
+          scheduleCandidates: candidates,
+          loading: false
+      );
+    }catch(e){
+      debugPrint(e.toString());
+    }
+  }
+
+  Future<void> initialize() async {
+    try{
+      state = state.copyWith(event: const Event(
+              id: null,
+              name: null,
+              description: null,
+              start_at: null,
+              end_at: null,
+              img_url: null,
+              location_name: null,
+              location_address: null,
+              location_latitude: null,
+              location_longitude: null,
+              group_num: null,
+              cost: null,
+              cost_type: null,
+              questionare_url: null
+          ),
+          participants: [],
+          scheduleCandidates: SplayTreeSet<ScheduleCandidate>((a, b) => a.getText().compareTo(b.getText()))
+      );
+    }catch(e){
+      debugPrint(e.toString());
+    }
+  }
+
+  void changeName(String? name) {
+    final event = state.event.copyWith(name: name);
+    state = state.copyWith(event: event);
+  }
+
+  void changeDescription(String? description) {
+    final event = state.event.copyWith(description: description);
+    state = state.copyWith(event: event);
+  }
+
+
+  Future<int> updateDescription(String? description) async{
+    final data = {
+      'description': description
+    };
+    final status = await testService.updateEvent(data);
+    return status;
+  }
+
+  Future<int> updateScheduleCandidates() async{
+    final data = state.scheduleCandidates.map((e) => e.toJson()).toList();
+    for (var e in data) {
+      e.removeWhere((key, value) => key == 'voters');
+    }
+    print(data);
+    final status = await testService.updateScheduleCandidates(state.event.id, data);
+    return status;
+  }
+
+  Future<int> updateLocationInformation(String name, String address, double latitude, double longitude) async {
+    final data = {
+      'location_address': address,
+      'location_name': name,
+      'location_latitude': latitude,
+      'location_longitude': longitude,
+    };
+    final status = await testService.updateEvent(data);
+    return status;
+  }
+
+  Future<int> updateSplittingInformation(int? cost, int costType) async {
+    final data = {
+      'cost': cost,
+      'cost_type': costType
+    };
+    final status = await testService.updateEvent(data);
+    return status;
+  }
+
+  void addPeriod(ScheduleCandidate period) {
+    state.scheduleCandidates.add(period);
+    state = state.copyWith(scheduleCandidates: state.scheduleCandidates);
+  }
+
+  void removePeriod(ScheduleCandidate period) {
+    state.scheduleCandidates.remove(period);
+    state = state.copyWith(scheduleCandidates: state.scheduleCandidates);
+  }
+
+  void changeLoading(bool loading) {
+    state = state.copyWith(loading: loading);
+  }
+
+  Future<int> createEvent() async {
+    // TODO apiにnameとdescriptionを渡し返り値でイベントのidを受け取るやつを記述する。
+    return 1;
+  }
+}
+
+final eventUpdateProvider = StateNotifierProvider<EventUpdateNotifier
+,EventUpdateState>((ref) {
+  return EventUpdateNotifier();
+});

--- a/lib/provider/event_update_provider.dart
+++ b/lib/provider/event_update_provider.dart
@@ -155,9 +155,14 @@ class EventUpdateNotifier extends StateNotifier<EventUpdateState> {
     state = state.copyWith(loading: loading);
   }
 
-  Future<int> createEvent() async {
+  Future<Map<String, int>> createEvent() async {
     // TODO apiにnameとdescriptionを渡し返り値でイベントのidを受け取るやつを記述する。
-    return 1;
+    final data = {
+      'name': state.event.name,
+      'description': state.event.description
+    };
+    final set = testService.createEvent(data);
+    return set;
   }
 }
 

--- a/lib/widget/components/schedule/event_list_item.dart
+++ b/lib/widget/components/schedule/event_list_item.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../model/entity/event.dart';
+import '../../../provider/event_list_provider.dart';
 
-class EventListItemComponent extends StatelessWidget {
+class EventListItemComponent extends HookConsumerWidget {
   final Widget leading;
   final Event event;
   // final Color tileColor;
@@ -10,13 +12,17 @@ class EventListItemComponent extends StatelessWidget {
   const EventListItemComponent({Key? key, required this.event, required this.leading}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(eventListProvider.notifier);
     return ListTile(
       title: Text(event.name ?? ''),
       subtitle: Text(event.description ?? ''),
       leading: leading,
       onTap: () => {
         Navigator.of(context).pushNamed("/event/detail", arguments: {'id': event.id})
+          .then((value) async {
+            await notifier.getEvents();
+          })
       },
       onLongPress: () => {},
       trailing: const Icon(Icons.more_vert),

--- a/lib/widget/components/schedule/schedule_day_list_tile.dart
+++ b/lib/widget/components/schedule/schedule_day_list_tile.dart
@@ -2,26 +2,30 @@ import 'dart:collection';
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:schetify/model/entity/schedule_period.dart';
-import 'package:schetify/provider/schedule_day_provider.dart';
+import 'package:schetify/model/entity/schedule_candidate.dart';
+
+import '../../../provider/event_update_provider.dart';
 
 @immutable
 class ScheduleDayListTile extends HookConsumerWidget {
-  const ScheduleDayListTile({Key? key, required this.periodList, required this.index}) : super(key: key);
+  const ScheduleDayListTile({Key? key, required this.scheduleCandidates, required this.index, required this.eventId}) : super(key: key);
 
-  final SplayTreeSet<SchedulePeriod> periodList;
+  final SplayTreeSet<ScheduleCandidate> scheduleCandidates;
   final int index;
+  final int? eventId;
 
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(eventUpdateProvider.notifier);
+
     return ListTile(
       dense: true,
-      title: Text(periodList.elementAt(index).getText()),
+      title: Text(scheduleCandidates.elementAt(index).getText()),
       trailing: IconButton(
         icon: const Icon(Icons.edit_note),
         onPressed: () async {
-          final period = periodList.elementAt(index);
+          final period = scheduleCandidates.elementAt(index);
           TimeOfDay initialStartTimeOfDay = const TimeOfDay(hour: 19, minute: 0);
           TimeOfDay initialEndTimeOfDay = const TimeOfDay(hour: 20, minute: 0);
           final startTimeOfDay = await showTimePicker(
@@ -31,9 +35,9 @@ class ScheduleDayListTile extends HookConsumerWidget {
           );
           if(startTimeOfDay != null) {
             final startTime = DateTime(
-                period.startTime.year,
-                period.startTime.month,
-                period.startTime.day,
+                period.start_at.year,
+                period.start_at.month,
+                period.start_at.day,
                 startTimeOfDay.hour,
                 startTimeOfDay.minute
             );
@@ -44,20 +48,21 @@ class ScheduleDayListTile extends HookConsumerWidget {
             );
             if(endTimeOfDay != null) {
               final endTime = DateTime(
-                  period.endTime.year,
-                  period.endTime.month,
-                  period.endTime.day,
+                  period.end_at.year,
+                  period.end_at.month,
+                  period.end_at.day,
                   endTimeOfDay.hour,
                   endTimeOfDay.minute
               );
-              final newPeriod = SchedulePeriod(
-                  startTime: startTime,
-                  endTime: endTime
+              final newPeriod = ScheduleCandidate(
+                id: null,
+                event_id: eventId,
+                start_at: startTime,
+                end_at: endTime,
+                voters: [],
               );
-              ref.read(scheduleDayProvider.notifier)
-                  .removePeriod(periodList.elementAt(index));
-              ref.read(scheduleDayProvider.notifier)
-                  .addPeriod(newPeriod);
+              notifier.removePeriod(scheduleCandidates.elementAt(index));
+              notifier.addPeriod(newPeriod);
             }
           }
         },

--- a/lib/widget/components/schedule/schedule_day_list_view.dart
+++ b/lib/widget/components/schedule/schedule_day_list_view.dart
@@ -2,27 +2,29 @@ import 'dart:collection';
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:schetify/model/entity/schedule_candidate.dart';
 import 'package:schetify/widget/components/schedule/schedule_day_list_tile.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
-import 'package:schetify/model/entity/schedule_period.dart';
-import 'package:schetify/provider/schedule_day_provider.dart';
+
+import '../../../provider/event_update_provider.dart';
 
 class ScheduleDayListView extends HookConsumerWidget {
-  ScheduleDayListView({Key? key, required this.periodList, required this.scrollController}) : super(key: key);
+  ScheduleDayListView({Key? key, required this.scheduleCandidates, required this.scrollController, required this.eventId}) : super(key: key);
 
-  final SplayTreeSet<SchedulePeriod> periodList;
+  final SplayTreeSet<ScheduleCandidate> scheduleCandidates;
   final ItemScrollController scrollController;
   final ItemPositionsListener positionsListener = ItemPositionsListener.create();
+  final int? eventId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(eventUpdateProvider.notifier);
     return ScrollablePositionedList.builder(
       padding: const EdgeInsets.symmetric(vertical: 8),
       itemBuilder: (context, index) {
         return Dismissible(
           key: UniqueKey(),
-          onDismissed: (direction) => ref.read(scheduleDayProvider.notifier)
-              .removePeriod(periodList.elementAt(index)),
+          onDismissed: (direction) => notifier.removePeriod(scheduleCandidates.elementAt(index)),
           background: Container(
             color: Colors.red,
             child: const Icon(Icons.delete, color: Colors.white),
@@ -31,7 +33,7 @@ class ScheduleDayListView extends HookConsumerWidget {
             children: [
               Container( // SizedBoxにした方がいいというWarningが出るが、パッケージの挙動がおかしくなるのでContainerのままにした
                 height: 30,
-                child: ScheduleDayListTile(periodList: periodList, index: index,),
+                child: ScheduleDayListTile(scheduleCandidates: scheduleCandidates, index: index, eventId: eventId,),
               ),
               const Divider()
             ],
@@ -40,6 +42,6 @@ class ScheduleDayListView extends HookConsumerWidget {
       },
       itemScrollController: scrollController,
       itemPositionsListener: positionsListener,
-      itemCount: periodList.length);
+      itemCount: scheduleCandidates.length);
   }
 }

--- a/lib/widget/components/schedule/sub_list_item.dart
+++ b/lib/widget/components/schedule/sub_list_item.dart
@@ -1,20 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:schetify/widget/dialog/event_detail_dialog.dart';
 import 'package:schetify/widget/dialog/splitting_the_cost_dialog.dart';
 
+import '../../../provider/event_update_provider.dart';
 import '../../dialog/splitting_the_cost_dialog.dart';
 
-class SubListItem extends StatelessWidget {
+class SubListItem extends HookConsumerWidget {
   final String title;
   final Widget leading;
   final String route;
   final String toggle;
   final String address;
+  final int? eventId;
 
-  SubListItem({required this.title, required this.leading, required this.route, required this.toggle, required this.address});
+  const SubListItem({required this.title, required this.leading, required this.route, required this.toggle, required this.address, required this.eventId});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(eventUpdateProvider.notifier);
     return ListTile(
       title: Row(
         mainAxisSize: MainAxisSize.min,
@@ -55,6 +59,9 @@ class SubListItem extends StatelessWidget {
           )
         }else{
           Navigator.of(context).pushNamed(route)
+            .then((value) {
+              notifier.getEventInformation(eventId!);
+          })
         }
       },
       // onLongPress: () => {},

--- a/lib/widget/dialog/event_detail_dialog.dart
+++ b/lib/widget/dialog/event_detail_dialog.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:schetify/provider/event_description_provider.dart';
+
+import '../../provider/event_update_provider.dart';
 
 class EventDetailDialog extends HookConsumerWidget {
 
@@ -10,25 +11,47 @@ class EventDetailDialog extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
 
-    final provider = ref.watch(eventDescriptionProvider);
-    final detailText = useState(provider.detail);
+    final notifier = ref.read(eventUpdateProvider.notifier);
+    final detail = ref.watch(eventUpdateProvider);
+    final detailText = useState(detail.event.description);
+
+    SnackBar alertSnackBar = SnackBar(
+      content: const Text('更新に失敗しました。'),
+      action: SnackBarAction(
+        label: '閉じる',
+        onPressed: (){
+          //閉じるが押された時行いたい処理
+        },
+      ),
+    );
+
+    void updateText(String? text) {
+      detailText.value = text;
+    }
 
     return Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             TextFormField(
-              initialValue: detailText.value,
+              initialValue: detail.event.description,
               keyboardType: TextInputType.multiline,
               maxLines: null,
-                onChanged: (text){
-                  detailText.value = text;
-                }
+                onChanged: updateText
             ),ListTile(
               title: const Text('保存'),
-              onTap: () {
-              ref.read(eventDescriptionProvider.notifier).changeDescription(detailText.value);
-              Navigator.of(context).pop();},
+              onTap: () async {
+                await notifier.updateDescription(detailText.value)
+                    .then((status) {
+                      if(status == 200) {
+                        Navigator.of(context).pop();
+                        notifier.getEventInformation(detail.event.id ?? -1);
+                      }
+                      else {
+                        ScaffoldMessenger.of(context).showSnackBar(alertSnackBar);
+                      }
+                });
+              },
             ),
           ],
         ),

--- a/lib/widget/page/event_page.dart
+++ b/lib/widget/page/event_page.dart
@@ -30,7 +30,7 @@ class EventPage extends HookConsumerWidget {
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: (){
-          Navigator.of(context).pushNamed("/schedule/new");
+          Navigator.of(context).pushNamed("/event/new");
         },
         tooltip: 'Increment',
         child: const Icon(Icons.add),

--- a/lib/widget/page/schedule/common/event_detail_page.dart
+++ b/lib/widget/page/schedule/common/event_detail_page.dart
@@ -15,6 +15,7 @@ class EventDetailPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final detail = ref.watch(eventDetailProvider);
+    final notifier = ref.read(eventDetailProvider.notifier);
     final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
     int maxFitnessValue = -1;
 
@@ -243,8 +244,10 @@ class EventDetailPage extends HookConsumerWidget {
                                                           fontSize: 12
                                                       )
                                                   ),
-                                                  onPressed: () {
+                                                  onPressed: () async{
                                                     // TODO APIを叩いてイベントのstart_at, end_atを更新し、再度イベントを読み込むようにする
+                                                    await notifier.updateSchedule(candidate.start_at, candidate.end_at);
+                                                    await updateEventInformation();
                                                   },
                                                 ),
                                               ),

--- a/lib/widget/page/schedule/common/event_detail_page.dart
+++ b/lib/widget/page/schedule/common/event_detail_page.dart
@@ -16,13 +16,11 @@ class EventDetailPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final detail = ref.watch(eventDetailProvider);
     final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
-    final loading = useState(true);
     int maxFitnessValue = -1;
 
     Future<void> updateEventInformation() async{
       await ref.read(eventDetailProvider.notifier)
           .getEventInformation(args['id']);
-      loading.value = false;
       maxFitnessValue = detail.scheduleCandidates
           .toList()
           .map((e) {
@@ -53,9 +51,9 @@ class EventDetailPage extends HookConsumerWidget {
 
     return Scaffold(
         appBar: AppBar(
-          title: loading.value ? const Text('読み込み中...') : Text(detail.event.name ?? ''),
+          title: detail.loading ? const Text('読み込み中...') : Text(detail.event.name ?? ''),
         ),
-        body: loading.value ? Container(
+        body: detail.loading ? Container(
             alignment: Alignment.center,
             child: const CircularProgressIndicator(
               color: Colors.green,

--- a/lib/widget/page/schedule/common/event_new_page.dart
+++ b/lib/widget/page/schedule/common/event_new_page.dart
@@ -12,6 +12,16 @@ class EventCreatePage extends HookConsumerWidget {
     final notifier = ref.read(eventUpdateProvider.notifier);
     final detail = ref.watch(eventUpdateProvider);
 
+    SnackBar alertSnackBar = SnackBar(
+      content: const Text('作成に失敗しました。'),
+      action: SnackBarAction(
+        label: '閉じる',
+        onPressed: (){
+          //閉じるが押された時行いたい処理
+        },
+      ),
+    );
+
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         Future<void>.microtask(() async {
@@ -80,10 +90,15 @@ class EventCreatePage extends HookConsumerWidget {
                     child: ElevatedButton(
                       onPressed: () {
                         notifier.createEvent()
-                        .then((id) {
+                        .then((set) {
                           // APIから保存して返り値のイベントidを受け取る
-                          Navigator.of(context).pop();
-                          Navigator.of(context).pushNamed("/schedule/new", arguments: {'id': id});
+                          if(set['status'] == 200) {
+                            Navigator.of(context).pop();
+                            Navigator.of(context).pushNamed("/schedule/new", arguments: {'id': set['id']});
+                          }
+                          else {
+                            ScaffoldMessenger.of(context).showSnackBar(alertSnackBar);
+                          }
                         });
                       },
                       child: const Text('作成'),

--- a/lib/widget/page/schedule/common/event_new_page.dart
+++ b/lib/widget/page/schedule/common/event_new_page.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../../../../provider/event_update_provider.dart';
+
+class EventCreatePage extends HookConsumerWidget {
+  const EventCreatePage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final loading = useState(true);
+    final notifier = ref.read(eventUpdateProvider.notifier);
+    final detail = ref.watch(eventUpdateProvider);
+
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        Future<void>.microtask(() async {
+          await notifier.initialize();
+          loading.value = false;
+        });
+      });
+      return null;
+    }, const []);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("予定作成"),
+      ),
+      body: loading.value ? Container(
+          alignment: Alignment.center,
+          child: const CircularProgressIndicator(
+            color: Colors.green,
+          )
+      ) : Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Column(
+            children: [
+              Container(
+                alignment: const Alignment(0.0, 0.0),
+                height: 100,
+                child: TextFormField(
+                  style: const TextStyle(
+                    fontSize: 30,
+                  ),
+                  initialValue: detail.event.name,
+                  decoration: InputDecoration(
+                    hintText: '予定名',
+                    contentPadding: const EdgeInsets.all(20),
+                    fillColor: Colors.green[100],
+                    filled: true,
+                    isDense: true,
+                    prefixIcon: Container(
+                      margin: const EdgeInsets.all(20),
+                      child: const Icon(
+                        Icons.event_available,
+                        size: 40,
+                      ),
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(32),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                  onChanged: notifier.changeName,
+                ),
+              ),
+              TextFormField(
+                initialValue: detail.event.description,
+                decoration: const InputDecoration(
+                  labelText: '説明',
+                ),
+                keyboardType: TextInputType.multiline,
+                maxLines: null,
+                onChanged: notifier.changeDescription,
+              ),
+              Padding(
+                  padding: const EdgeInsets.all(30.0),
+                  child: SizedBox(
+                    height: 50,
+                    width: 100,
+                    child: ElevatedButton(
+                      onPressed: () {
+                        notifier.createEvent()
+                        .then((id) {
+                          // APIから保存して返り値のイベントidを受け取る
+                          Navigator.of(context).pop();
+                          Navigator.of(context).pushNamed("/schedule/new", arguments: {'id': id});
+                        });
+                      },
+                      child: const Text('作成'),
+                    ),
+                  ),
+              )
+            ],
+          )
+      )
+  );
+  }
+}

--- a/lib/widget/page/schedule/common/schedule_update_page.dart
+++ b/lib/widget/page/schedule/common/schedule_update_page.dart
@@ -28,6 +28,16 @@ class ScheduleUpdatePage extends HookConsumerWidget {
     final notifier = ref.read(eventUpdateProvider.notifier);
     final detail = ref.watch(eventUpdateProvider);
 
+    SnackBar alertSnackBar = SnackBar(
+      content: const Text('更新に失敗しました。'),
+      action: SnackBarAction(
+        label: '閉じる',
+        onPressed: (){
+          //閉じるが押された時行いたい処理
+        },
+      ),
+    );
+
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
         Future<void>.microtask(() async {
@@ -78,7 +88,17 @@ class ScheduleUpdatePage extends HookConsumerWidget {
                   borderSide: BorderSide.none,
                 ),
               ),
-              onFieldSubmitted: print,
+              onFieldSubmitted: (value) async {
+                await notifier.updateName(value)
+                    .then((status){
+                      if(status == 200) {
+                        notifier.getEventInformation(args?['id'] ?? -1);
+                      }
+                      else {
+                        ScaffoldMessenger.of(context).showSnackBar(alertSnackBar);
+                      }
+                });
+              }
             ),
           ),
           Expanded(child: ListView.separated(

--- a/lib/widget/page/schedule/common/schedule_update_page.dart
+++ b/lib/widget/page/schedule/common/schedule_update_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import '../../../../model/entity/schedule_update_page_util.dart';
+import '../../../../provider/event_update_provider.dart';
 import '../../../components/schedule/sub_list_item.dart';
 
 class ScheduleUpdatePage extends HookConsumerWidget {
@@ -19,15 +21,36 @@ class ScheduleUpdatePage extends HookConsumerWidget {
 
   // tentative variable
   String toggleState = "ON";
-  String address = "東京都世田谷区北沢３丁目２３−１４";
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>?;
+    final notifier = ref.read(eventUpdateProvider.notifier);
+    final detail = ref.watch(eventUpdateProvider);
+
+    useEffect(() {
+      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+        Future<void>.microtask(() async {
+          if(args != null) {
+            await notifier.getEventInformation(args['id']);
+          }
+          else {
+            await notifier.initialize();
+          }
+        });
+      });
+      return null;
+    }, const []);
     return Scaffold(
       appBar: AppBar(
-        title: const Text("予定作成&編集"),
+        title: Text("予定${args != null ? '編集' : '作成'}"),
       ),
-      body: Column(
+      body: detail.loading ? Container(
+          alignment: Alignment.center,
+          child: const CircularProgressIndicator(
+            color: Colors.green,
+          )
+      ) : Column(
         children: [
           Container(
             alignment: const Alignment(0.0, 0.0),
@@ -36,6 +59,7 @@ class ScheduleUpdatePage extends HookConsumerWidget {
               style: const TextStyle(
                 fontSize: 30,
               ),
+              initialValue: detail.event.name,
               decoration: InputDecoration(
                 hintText: '予定名',
                 contentPadding: const EdgeInsets.all(20),
@@ -54,6 +78,7 @@ class ScheduleUpdatePage extends HookConsumerWidget {
                   borderSide: BorderSide.none,
                 ),
               ),
+              onFieldSubmitted: print,
             ),
           ),
           Expanded(child: ListView.separated(
@@ -71,7 +96,8 @@ class ScheduleUpdatePage extends HookConsumerWidget {
                 ),
                 route: util[index].routeName,
                 toggle: util[index].tileName == '出席' ? toggleState : '',
-                address: util[index].tileName == '目的地:' ? address : '',
+                address: util[index].tileName == '目的地:' ? detail.event.getLocationText() : '',
+                eventId: detail.event.id,
               );
             },
             separatorBuilder: (BuildContext context, int index) => const Divider(),

--- a/lib/widget/page/schedule/common/schedule_update_page.dart
+++ b/lib/widget/page/schedule/common/schedule_update_page.dart
@@ -14,7 +14,6 @@ class ScheduleUpdatePage extends HookConsumerWidget {
     ScheduleUpdatePageUtil("割り勘設定", "cost", const Icon(Icons.money)),
     ScheduleUpdatePageUtil("目的地:", "/schedule/new/destination", const Icon(Icons.room),),
     ScheduleUpdatePageUtil("アンケート設定", "/schedule/new/questionnaire", const Icon(Icons.feed)),
-    ScheduleUpdatePageUtil("出席", "", const Icon(Icons.confirmation_num)),
     ScheduleUpdatePageUtil("シェア(URL)", "", const Icon(Icons.add_link)),
   ];
 

--- a/lib/widget/page/schedule/common/seat_distribution.dart
+++ b/lib/widget/page/schedule/common/seat_distribution.dart
@@ -1,17 +1,12 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:schetify/model/entity/number_of_groups.dart';
-import 'package:schetify/model/entity/user_name_list.dart';
 import 'package:schetify/provider/grouping_provider.dart';
-
-import '../../model/entity/user_name.dart';
 
 
 
 class SeatDistribution extends HookConsumerWidget {
-  SeatDistribution({Key? key}) : super(key: key);
+  const SeatDistribution({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -29,7 +24,7 @@ class SeatDistribution extends HookConsumerWidget {
                 itemBuilder: (BuildContext context, int index) {
                   return Column(
                     children: [
-                      Text("Group ${index}"),
+                      Text("Group $index"),
                       for (var i = 0; i < provider.groupedUserList[index].userNameList.length; i++)
                         Text(provider.groupedUserList[index].userNameList[i].name),
                     ],

--- a/lib/widget/router.dart
+++ b/lib/widget/router.dart
@@ -8,12 +8,13 @@ import 'package:schetify/widget/page/init/user_registration_page.dart';
 import 'package:schetify/widget/page/main_page.dart';
 import 'package:schetify/widget/page/schedule/common/attendance_check_page.dart';
 import 'package:schetify/widget/page/schedule/common/event_detail_page.dart';
+import 'package:schetify/widget/page/schedule/common/event_new_page.dart';
 import 'package:schetify/widget/page/schedule/common/question/question.dart';
 import 'package:schetify/widget/page/schedule/common/schedule_update_destination_page.dart';
 import 'package:schetify/widget/page/schedule/common/label/settings_label.dart';
 import 'package:schetify/widget/page/schedule/common/schedule_update_page.dart';
 import 'package:schetify/widget/page/schedule/common/schedule_day_update_page.dart';
-import 'package:schetify/widget/page/seat_distribution.dart';
+import 'package:schetify/widget/page/schedule/common/seat_distribution.dart';
 import 'package:schetify/widget/page/setting/account/change_password/change_password.dart';
 import 'package:schetify/widget/page/setting/account/change_password/enter_password.dart';
 import 'package:schetify/widget/page/setting/account/settings_account.dart';
@@ -48,10 +49,11 @@ class AppRouter extends ConsumerWidget {
         '/init/register': (BuildContext context) => const UserRegistrationPage(),
         '/init/login': (BuildContext context) => const LoginPage(),
         '/schedule/new/label': (BuildContext context) => const SettingsLabel(),
-        '/schedule/new/seat': (BuildContext context) => SeatDistribution(),
+        '/schedule/new/seat': (BuildContext context) => const SeatDistribution(),
         '/schedule/attendance': (BuildContext context) => const AttendanceCheckPage(),
         '/event/detail': (BuildContext context) => const EventDetailPage(),
         '/event/': (BuildContext context) => const EventPage(),
+        '/event/new': (BuildContext context) => const EventCreatePage(),
       },
     );
   }


### PR DESCRIPTION
関連イシュー: #24

## やったこと

- ラベル設定、席分け設定以外をAPI通信する形に変更、修正 